### PR TITLE
Add javax.annotation 1.2 bundle to Weld tests

### DIFF
--- a/pax-cdi-itest-weld/src/test/java/org/ops4j/pax/cdi/test/weld/ServletTest.java
+++ b/pax-cdi-itest-weld/src/test/java/org/ops4j/pax/cdi/test/weld/ServletTest.java
@@ -67,6 +67,7 @@ public class ServletTest {
         return options(
             regressionDefaults(),
 
+
             workspaceBundle("pax-cdi-samples/pax-cdi-sample1"),
             workspaceBundle("pax-cdi-samples/pax-cdi-sample1-client"),
             
@@ -86,6 +87,7 @@ public class ServletTest {
             mavenBundle("ch.qos.cal10n", "cal10n-api", "0.7.4"),
             mavenBundle("org.apache.xbean", "xbean-bundleutils").versionAsInProject(),
             mavenBundle("org.apache.xbean", "xbean-finder").versionAsInProject(),
+            mavenBundle("javax.el", "javax.el-api").version("3.0.0"),
             mavenBundle("org.apache.geronimo.specs", "geronimo-interceptor_1.1_spec")
                 .versionAsInProject(),
             

--- a/pax-cdi-itest-weld/src/test/java/org/ops4j/pax/cdi/test/weld/TestConfiguration.java
+++ b/pax-cdi-itest-weld/src/test/java/org/ops4j/pax/cdi/test/weld/TestConfiguration.java
@@ -24,6 +24,7 @@ import static org.ops4j.pax.exam.CoreOptions.composite;
 import static org.ops4j.pax.exam.CoreOptions.frameworkStartLevel;
 import static org.ops4j.pax.exam.CoreOptions.junitBundles;
 import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
+import static org.ops4j.pax.exam.CoreOptions.systemPackage;
 import static org.ops4j.pax.exam.CoreOptions.systemProperty;
 import static org.ops4j.pax.exam.CoreOptions.systemTimeout;
 
@@ -52,6 +53,12 @@ public class TestConfiguration {
 
     public static Option regressionDefaults() {
         return composite(
+            /*
+             *  This is a HACK to make pax-cdi-sample1 pick the provided javax.annotation API instead of the one
+             *  from system bundle. Otherwise, the sample for some reason uses javax.annotation from the system bundle
+             *  while Weld uses the one from Maven. As the result, annotations like @PostConstruct are not detected by Weld.
+             */
+            systemPackage("javax.annotation;version=10.0.0"),
 
             cleanCaches(),
             frameworkStartLevel(20),

--- a/pax-cdi-itest-weld/src/test/java/org/ops4j/pax/cdi/test/weld/WeldProducerAndClientTest.java
+++ b/pax-cdi-itest-weld/src/test/java/org/ops4j/pax/cdi/test/weld/WeldProducerAndClientTest.java
@@ -56,6 +56,8 @@ public class WeldProducerAndClientTest {
         return options(
             regressionDefaults(),
 
+            mavenBundle("javax.annotation", "javax.annotation-api").version("1.2"),
+
             workspaceBundle("pax-cdi-samples/pax-cdi-sample1"),
             workspaceBundle("pax-cdi-samples/pax-cdi-sample1-client"),
             workspaceBundle("pax-cdi-extender"),

--- a/pax-cdi-itest-weld/src/test/java/org/ops4j/pax/cdi/test/weld/WeldSingleBundleTest.java
+++ b/pax-cdi-itest-weld/src/test/java/org/ops4j/pax/cdi/test/weld/WeldSingleBundleTest.java
@@ -64,6 +64,8 @@ public class WeldSingleBundleTest {
         return options(
             regressionDefaults(),
 
+            mavenBundle("javax.annotation", "javax.annotation-api").version("1.2"),
+
             workspaceBundle("pax-cdi-samples/pax-cdi-sample1"),
             workspaceBundle("pax-cdi-extender"),
             workspaceBundle("pax-cdi-extension"),


### PR DESCRIPTION
This is necessary for Weld 2.x to work correctly (the Priority annotation). 

I was not able to ban the javax.annotation;version="0.0" export of the system bundle. For some reason (probably lack of knowledge on my part) the sample bundle keeps resolving to the javax.annotation package exported by the system bundle instead of the one provided by javax.annotation 1.2 bundle. This causes problems with Weld as two classes with the same name are loaded (e.g. javax.annotation.PostConstruct) Therefore, I added a hack to force the sample bundle to resolve to the javax.annotation 1.2 bundle by overriding the version of javax.annotation package provided by the system bundle to a non-sensible number. I cannot deal with the situation otherwise. Any tips welcome.
