### PR TITLE
[PAXCDI-143] Use Bundle Class Loader as a TCCL on Weld shutdown

### DIFF
--- a/pax-cdi-weld/src/main/java/org/ops4j/pax/cdi/weld/impl/WeldCdiContainer.java
+++ b/pax-cdi-weld/src/main/java/org/ops4j/pax/cdi/weld/impl/WeldCdiContainer.java
@@ -119,7 +119,20 @@ public class WeldCdiContainer extends AbstractCdiContainer {
 
     @Override
     public void doStop() {
-        bootstrap.shutdown();
+        try {
+            doWithClassLoader(getContextClassLoader(), new Callable<Object>() {
+
+                @Override
+                public Object call() throws Exception {
+                    bootstrap.shutdown();
+                    return null;
+                }
+            });
+        }
+        // CHECKSTYLE:SKIP
+        catch (Exception exc) {
+            throw new Ops4jException(exc);
+        }
     }
 
     @Override


### PR DESCRIPTION
Setup bundle class loader as a TCCL in WeldCdiContainer#doStop() like WeldCdiContainer#doStart() is doing already.
