### PR TITLE
Split itest-karaf testsuite into packages

### DIFF
--- a/itest/src/it/itest-karaf/pom.xml
+++ b/itest/src/it/itest-karaf/pom.xml
@@ -267,6 +267,9 @@
                         <pax.cdi.provider>${pax.cdi.provider}</pax.cdi.provider>
                         <pax.exam.karaf.version>${karaf.version}</pax.exam.karaf.version>
                     </systemPropertyVariables>
+                    <includes>
+                        <include>**/${pax.cdi.provider.name}/**</include>
+                    </includes>
                 </configuration>
             </plugin>
         </plugins>
@@ -307,6 +310,7 @@
             </activation>
             <properties>
                 <pax.cdi.provider>owb1</pax.cdi.provider>
+                <pax.cdi.provider.name>owb</pax.cdi.provider.name>
             </properties>
             <dependencies>
 
@@ -333,6 +337,7 @@
             </activation>
             <properties>
                 <pax.cdi.provider>weld1</pax.cdi.provider>
+                <pax.cdi.provider.name>weld</pax.cdi.provider.name>
             </properties>
             <dependencies>
 
@@ -364,6 +369,7 @@
             </activation>
             <properties>
                 <pax.cdi.provider>weld2</pax.cdi.provider>
+                <pax.cdi.provider.name>weld</pax.cdi.provider.name>
             </properties>
             <dependencies>
 

--- a/itest/src/it/itest-karaf/src/test/java/org/ops4j/pax/cdi/test/karaf/owb/PaxCdiOpenWebBeansTest.java
+++ b/itest/src/it/itest-karaf/src/test/java/org/ops4j/pax/cdi/test/karaf/owb/PaxCdiOpenWebBeansTest.java
@@ -15,14 +15,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.ops4j.pax.cdi.test.karaf;
+package org.ops4j.pax.cdi.test.karaf.owb;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
 import static org.ops4j.pax.cdi.test.karaf.RegressionConfiguration.PAX_CDI_FEATURES;
-import static org.ops4j.pax.cdi.test.karaf.RegressionConfiguration.PAX_WEB_FEATURES;
-import static org.ops4j.pax.cdi.test.karaf.RegressionConfiguration.SAMPLE1_WEB;
+import static org.ops4j.pax.cdi.test.karaf.RegressionConfiguration.SAMPLE1;
 import static org.ops4j.pax.cdi.test.karaf.RegressionConfiguration.regressionDefaults;
 import static org.ops4j.pax.exam.CoreOptions.options;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.features;
@@ -31,28 +30,32 @@ import javax.inject.Inject;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.ops4j.pax.cdi.sample1.IceCreamService;
 import org.ops4j.pax.cdi.spi.CdiContainerFactory;
 import org.ops4j.pax.exam.Configuration;
 import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.junit.PaxExam;
 
 @RunWith(PaxExam.class)
-public class PaxCdiWebOpenWebBeansTest {
+public class PaxCdiOpenWebBeansTest {
 
     @Inject
     private CdiContainerFactory factory;
+    
+    @Inject
+    private IceCreamService iceCreamService;
 
     @Configuration
     public Option[] config() {
-        return options(
+        return options( 
             regressionDefaults(),
-            features(PAX_WEB_FEATURES, "war"),
-            features(PAX_CDI_FEATURES, "pax-cdi-web-openwebbeans"),
-            SAMPLE1_WEB);
+            features(PAX_CDI_FEATURES, "pax-cdi-openwebbeans"),
+            SAMPLE1);
     }
 
     @Test
     public void test() throws Exception {
         assertThat(factory, is(notNullValue()));
+        assertThat(iceCreamService, is(notNullValue()));
     }
 }

--- a/itest/src/it/itest-karaf/src/test/java/org/ops4j/pax/cdi/test/karaf/owb/PaxCdiWebOpenWebBeansTest.java
+++ b/itest/src/it/itest-karaf/src/test/java/org/ops4j/pax/cdi/test/karaf/owb/PaxCdiWebOpenWebBeansTest.java
@@ -15,13 +15,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.ops4j.pax.cdi.test.karaf;
+package org.ops4j.pax.cdi.test.karaf.owb;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
 import static org.ops4j.pax.cdi.test.karaf.RegressionConfiguration.PAX_CDI_FEATURES;
-import static org.ops4j.pax.cdi.test.karaf.RegressionConfiguration.SAMPLE1;
+import static org.ops4j.pax.cdi.test.karaf.RegressionConfiguration.PAX_WEB_FEATURES;
+import static org.ops4j.pax.cdi.test.karaf.RegressionConfiguration.SAMPLE1_WEB;
 import static org.ops4j.pax.cdi.test.karaf.RegressionConfiguration.regressionDefaults;
 import static org.ops4j.pax.exam.CoreOptions.options;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.features;
@@ -30,32 +31,28 @@ import javax.inject.Inject;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.ops4j.pax.cdi.sample1.IceCreamService;
 import org.ops4j.pax.cdi.spi.CdiContainerFactory;
 import org.ops4j.pax.exam.Configuration;
 import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.junit.PaxExam;
 
 @RunWith(PaxExam.class)
-public class PaxCdiOpenWebBeansTest {
+public class PaxCdiWebOpenWebBeansTest {
 
     @Inject
     private CdiContainerFactory factory;
-    
-    @Inject
-    private IceCreamService iceCreamService;
 
     @Configuration
     public Option[] config() {
-        return options( 
+        return options(
             regressionDefaults(),
-            features(PAX_CDI_FEATURES, "pax-cdi-openwebbeans"),
-            SAMPLE1);
+            features(PAX_WEB_FEATURES, "war"),
+            features(PAX_CDI_FEATURES, "pax-cdi-web-openwebbeans"),
+            SAMPLE1_WEB);
     }
 
     @Test
     public void test() throws Exception {
         assertThat(factory, is(notNullValue()));
-        assertThat(iceCreamService, is(notNullValue()));
     }
 }

--- a/itest/src/it/itest-karaf/src/test/java/org/ops4j/pax/cdi/test/karaf/weld/PaxCdiDeltaSpikeTest.java
+++ b/itest/src/it/itest-karaf/src/test/java/org/ops4j/pax/cdi/test/karaf/weld/PaxCdiDeltaSpikeTest.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.ops4j.pax.cdi.test.karaf;
+package org.ops4j.pax.cdi.test.karaf.weld;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;

--- a/itest/src/it/itest-karaf/src/test/java/org/ops4j/pax/cdi/test/karaf/weld/PaxCdiWebWeldTest.java
+++ b/itest/src/it/itest-karaf/src/test/java/org/ops4j/pax/cdi/test/karaf/weld/PaxCdiWebWeldTest.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.ops4j.pax.cdi.test.karaf;
+package org.ops4j.pax.cdi.test.karaf.weld;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;

--- a/itest/src/it/itest-karaf/src/test/java/org/ops4j/pax/cdi/test/karaf/weld/PaxCdiWeldTest.java
+++ b/itest/src/it/itest-karaf/src/test/java/org/ops4j/pax/cdi/test/karaf/weld/PaxCdiWeldTest.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.ops4j.pax.cdi.test.karaf;
+package org.ops4j.pax.cdi.test.karaf.weld;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;

--- a/pax-cdi-web-weld/pom.xml
+++ b/pax-cdi-web-weld/pom.xml
@@ -117,6 +117,7 @@
                         <Import-Package>
                             org.jboss.weld.*; version="[1,3)",
                             javax.servlet.*;version="[2,4)",
+                            javax.el.*;version="[2.2,4)",
                             *
                         </Import-Package>
                         <_dsannotations>*</_dsannotations>


### PR DESCRIPTION
Split itest-karaf so that only Weld tests are run with Weld profiles and vice versa. In addition, fix the problem with two dependency chains.