### PR TITLE
PAXCDI-157: OSGi dependencies should have scope "provided"

### DIFF
--- a/pax-cdi-api/pom.xml
+++ b/pax-cdi-api/pom.xml
@@ -4,7 +4,7 @@
         <groupId>org.ops4j.pax.cdi</groupId>
         <version>1.0.0-SNAPSHOT</version>
         <artifactId>pax-cdi-parent</artifactId>
-        <relativePath>../pax-cdi-parent</relativePath>
+        <relativePath>../pax-cdi-parent/pom.xml</relativePath>
     </parent>
     
     <artifactId>pax-cdi-api</artifactId>
@@ -22,11 +22,13 @@
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.core</artifactId>
+            <scope>provided</scope>
         </dependency>
     
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.compendium</artifactId>
+            <scope>provided</scope>
         </dependency>
     
         <dependency>

--- a/pax-cdi-extender/pom.xml
+++ b/pax-cdi-extender/pom.xml
@@ -55,6 +55,12 @@
             <artifactId>org.osgi.core</artifactId>
             <scope>provided</scope>
         </dependency>
+        
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.compendium</artifactId>
+            <scope>provided</scope>
+        </dependency>
 
         <dependency>
             <groupId>javax.enterprise</groupId>

--- a/pax-cdi-extender/pom.xml
+++ b/pax-cdi-extender/pom.xml
@@ -1,11 +1,11 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.ops4j.pax.cdi</groupId>
         <version>1.0.0-SNAPSHOT</version>
         <artifactId>pax-cdi-parent</artifactId>
-        <relativePath>../pax-cdi-parent</relativePath>
+        <relativePath>../pax-cdi-parent/pom.xml</relativePath>
     </parent>
     <artifactId>pax-cdi-extender</artifactId>
     <packaging>bundle</packaging>
@@ -53,6 +53,7 @@
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.core</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/pax-cdi-openwebbeans/pom.xml
+++ b/pax-cdi-openwebbeans/pom.xml
@@ -4,7 +4,7 @@
         <groupId>org.ops4j.pax.cdi</groupId>
         <version>1.0.0-SNAPSHOT</version>
         <artifactId>pax-cdi-parent</artifactId>
-        <relativePath>../pax-cdi-parent</relativePath>
+        <relativePath>../pax-cdi-parent/pom.xml</relativePath>
     </parent>
     <artifactId>pax-cdi-openwebbeans</artifactId>
     <packaging>bundle</packaging>
@@ -52,6 +52,13 @@
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.compendium</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/pax-cdi-test-support/pom.xml
+++ b/pax-cdi-test-support/pom.xml
@@ -4,7 +4,7 @@
         <groupId>org.ops4j.pax.cdi</groupId>
         <artifactId>pax-cdi-parent</artifactId>
         <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../pax-cdi-parent</relativePath>
+        <relativePath>../pax-cdi-parent/pom.xml</relativePath>
     </parent>
     <artifactId>pax-cdi-test-support</artifactId>
     
@@ -19,6 +19,12 @@
         <dependency>
             <groupId>org.ops4j.pax.exam</groupId>
             <artifactId>pax-exam</artifactId>
+        </dependency>
+        
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.core</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/pax-cdi-web-openwebbeans/pom.xml
+++ b/pax-cdi-web-openwebbeans/pom.xml
@@ -1,11 +1,11 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.ops4j.pax.cdi</groupId>
         <version>1.0.0-SNAPSHOT</version>
         <artifactId>pax-cdi-parent</artifactId>
-        <relativePath>../pax-cdi-parent</relativePath>
+        <relativePath>../pax-cdi-parent/pom.xml</relativePath>
     </parent>
     <artifactId>pax-cdi-web-openwebbeans</artifactId>
     <packaging>bundle</packaging>
@@ -120,6 +120,16 @@
             <scope>provided</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.compendium</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pax-cdi-web-weld/pom.xml
+++ b/pax-cdi-web-weld/pom.xml
@@ -5,7 +5,7 @@
         <groupId>org.ops4j.pax.cdi</groupId>
         <version>1.0.0-SNAPSHOT</version>
         <artifactId>pax-cdi-parent</artifactId>
-        <relativePath>../pax-cdi-parent</relativePath>
+        <relativePath>../pax-cdi-parent/pom.xml</relativePath>
     </parent>
 
     <artifactId>pax-cdi-web-weld</artifactId>
@@ -104,6 +104,11 @@
             <scope>provided</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.compendium</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pax-cdi-web/pom.xml
+++ b/pax-cdi-web/pom.xml
@@ -4,7 +4,7 @@
         <groupId>org.ops4j.pax.cdi</groupId>
         <version>1.0.0-SNAPSHOT</version>
         <artifactId>pax-cdi-parent</artifactId>
-        <relativePath>../pax-cdi-parent</relativePath>
+        <relativePath>../pax-cdi-parent/pom.xml</relativePath>
     </parent>
     <artifactId>pax-cdi-web</artifactId>
     <packaging>bundle</packaging>
@@ -47,11 +47,13 @@
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.core</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.compendium</artifactId>
+            <scope>provided</scope>
         </dependency>
 
     </dependencies>

--- a/pax-cdi-weld/pom.xml
+++ b/pax-cdi-weld/pom.xml
@@ -51,6 +51,12 @@
             <artifactId>org.osgi.core</artifactId>
             <scope>provided</scope>
         </dependency>
+        
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.compendium</artifactId>
+            <scope>provided</scope>
+        </dependency>
 
         <dependency>
             <groupId>javax.enterprise</groupId>

--- a/pax-cdi-weld/pom.xml
+++ b/pax-cdi-weld/pom.xml
@@ -4,7 +4,7 @@
         <groupId>org.ops4j.pax.cdi</groupId>
         <version>1.0.0-SNAPSHOT</version>
         <artifactId>pax-cdi-parent</artifactId>
-        <relativePath>../pax-cdi-parent</relativePath>
+        <relativePath>../pax-cdi-parent/pom.xml</relativePath>
     </parent>
 
     <artifactId>pax-cdi-weld</artifactId>
@@ -49,6 +49,7 @@
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.core</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
- org.osgi.core scope: provided
- org.osgi.compendium: provided
- missing dependencies added

I'm not very familiar with the compendium yet, but I think the scope "provided" is also correct for the compendium dependency.