### PR TITLE
Use jboss-classfilewriter bundle when running with Weld

### DIFF
--- a/pax-cdi-features/src/main/resources/features.xml
+++ b/pax-cdi-features/src/main/resources/features.xml
@@ -27,6 +27,7 @@
         <bundle dependency="true">mvn:org.jboss.weld/weld-osgi-bundle/${weld2.version}</bundle>
         <bundle>mvn:org.jboss.logging/jboss-logging/3.1.3.GA</bundle>
         <bundle>mvn:com.google.guava/guava/${guava.version}</bundle>
+        <bundle>mvn:org.jboss.classfilewriter/jboss-classfilewriter/1.1.1.Final</bundle>
         <bundle>mvn:org.ops4j.pax.cdi/pax-cdi-weld/${project.version}</bundle>
     </feature>
 

--- a/pax-cdi-test-support/src/main/java/org/ops4j/pax/cdi/test/support/TestConfiguration.java
+++ b/pax-cdi-test-support/src/main/java/org/ops4j/pax/cdi/test/support/TestConfiguration.java
@@ -270,6 +270,7 @@ public class TestConfiguration {
             workspaceBundle("org.ops4j.pax.cdi", "pax-cdi-weld"),
             mavenBundle("org.apache.xbean", "xbean-bundleutils", "4.1"),
             mavenBundle("org.jboss.logging", "jboss-logging", "3.1.3.GA"),
+            mavenBundle("org.jboss.classfilewriter", "jboss-classfilewriter", "1.1.1.Final"),
             mavenBundle("com.google.guava", "guava", "13.0.1"),
             mavenBundle("javax.enterprise", "cdi-api").versionAsInProject(),
             mavenBundle("javax.annotation", "javax.annotation-api", "1.2"),


### PR DESCRIPTION
This is in preparation for future Weld releases where jboss-classfilewriter will no longer be part of the Weld bundle
https://issues.jboss.org/browse/WELD-1946