### PR TITLE
Updated PAX-WEB to from 4.2.0-SNAPSHOT to 4.2.3 (Apache Karaf 4.0.3) …

### DIFF
--- a/pax-cdi-parent/pom.xml
+++ b/pax-cdi-parent/pom.xml
@@ -25,13 +25,13 @@
         <pax.jpa.version>0.3.0</pax.jpa.version>
         <pax.swissbox.version>1.8.0</pax.swissbox.version>
         <pax.url.version>2.2.0</pax.url.version>
-        <pax.web.version>4.2.0-SNAPSHOT</pax.web.version>
+        <pax.web.version>4.2.3</pax.web.version>
         <slf4j.version>1.6.4</slf4j.version>
         <weld.api.version>1.2.0.Beta1</weld.api.version>
         <weld.version>1.2.0.Beta1</weld.version>
         <weld2.version>2.2.12.Final</weld2.version>
         <xbean.version>4.1</xbean.version>
-        
+
         <servlet.spec.groupId>javax.servlet</servlet.spec.groupId>
 		<servlet.spec.artifactId>javax.servlet-api</servlet.spec.artifactId>
 		<servlet.spec.version>3.1.0</servlet.spec.version>

--- a/pax-cdi-web-openwebbeans/pom.xml
+++ b/pax-cdi-web-openwebbeans/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <bundle.symbolicName>org.ops4j.pax.cdi.web.openwebbeans</bundle.symbolicName>
         <bundle.namespace>org.ops4j.pax.cdi.web.openwebbeans</bundle.namespace>
-        <jetty.version>9.0.7.v20131107</jetty.version>
+		<jetty.version>9.2.10.v20150310</jetty.version>
     </properties>
 
     <dependencies>

--- a/pax-cdi-web-openwebbeans/src/main/java/org/ops4j/pax/cdi/web/openwebbeans/impl/JettyDecorator.java
+++ b/pax-cdi-web-openwebbeans/src/main/java/org/ops4j/pax/cdi/web/openwebbeans/impl/JettyDecorator.java
@@ -101,4 +101,15 @@ public class JettyDecorator implements ServletContextHandler.Decorator {
     public void destroyListenerInstance(EventListener listener) {
         getInjector().destroy(listener);
     }
+
+	@Override
+	public <T> T decorate(T o) {
+		getInjector().inject(o);
+		return o;
+	}
+
+	@Override
+	public void destroy(Object o) {
+		getInjector().destroy(o);
+	}
 }


### PR DESCRIPTION
…and adapted Jetty dependency versions from 9.0.7.v20131107 to 9.2.10.v20150310 to match the Jetty version of PAX-WEB 4.2.3 and adapted the JettyDecorator to that version