### PR TITLE
Cannot register beans created by producer methods as OSGi services

### DIFF
--- a/itest/src/it/itest-cdi10/pom.xml
+++ b/itest/src/it/itest-cdi10/pom.xml
@@ -115,6 +115,13 @@
         </dependency>
 
         <dependency>
+            <groupId>org.ops4j.pax.cdi.samples</groupId>
+            <artifactId>pax-cdi-sample-osgi-provider-producer-method</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.ops4j.pax.cdi</groupId>
             <artifactId>pax-cdi-extension</artifactId>
             <version>${project.version}</version>

--- a/itest/src/it/itest-cdi10/src/test/java/org/ops4j/pax/cdi/test/GreeterProducerTest.java
+++ b/itest/src/it/itest-cdi10/src/test/java/org/ops4j/pax/cdi/test/GreeterProducerTest.java
@@ -58,6 +58,6 @@ public class GreeterProducerTest {
 
     @Test
     public void checkInjection() throws InvalidSyntaxException {
-        assertEquals(greeter.sayHello(), "Bark!");
+        assertEquals(greeter.sayHello(), "Hello!");
     }
 }

--- a/itest/src/it/itest-cdi10/src/test/java/org/ops4j/pax/cdi/test/GreeterProducerTest.java
+++ b/itest/src/it/itest-cdi10/src/test/java/org/ops4j/pax/cdi/test/GreeterProducerTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2013 Harald Wellmann.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ops4j.pax.cdi.test;
+
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerClass;
+import org.osgi.framework.InvalidSyntaxException;
+import sample.osgiProviderProducerMethod.Greeter;
+
+import javax.inject.Inject;
+
+import static org.junit.Assert.assertEquals;
+import static org.ops4j.pax.cdi.test.support.TestConfiguration.cdiProviderBundles;
+import static org.ops4j.pax.cdi.test.support.TestConfiguration.paxCdiProviderAdapter;
+import static org.ops4j.pax.cdi.test.support.TestConfiguration.regressionDefaults;
+import static org.ops4j.pax.cdi.test.support.TestConfiguration.workspaceBundle;
+import static org.ops4j.pax.exam.CoreOptions.options;
+
+
+@RunWith(PaxExam.class)
+@ExamReactorStrategy(PerClass.class)
+public class GreeterProducerTest {
+
+    @Inject
+    private Greeter greeter;
+
+    @Configuration
+    public Option[] config() {
+        return options(
+                regressionDefaults(),
+
+                workspaceBundle("org.ops4j.pax.cdi.samples", "pax-cdi-sample-osgi-provider-producer-method"),
+
+                paxCdiProviderAdapter(),
+                cdiProviderBundles());
+    }
+
+    @Test
+    public void checkInjection() throws InvalidSyntaxException {
+        assertEquals(greeter.sayHello(), "Bark!");
+    }
+}

--- a/pax-cdi-samples/pax-cdi-sample-osgi-provider-producer-method/pom.xml
+++ b/pax-cdi-samples/pax-cdi-sample-osgi-provider-producer-method/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>pax-cdi-samples</artifactId>
+        <groupId>org.ops4j.pax.cdi</groupId>
+        <version>0.13.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.ops4j.pax.cdi.samples</groupId>
+    <artifactId>pax-cdi-sample-osgi-provider-producer-method</artifactId>
+    <packaging>bundle</packaging>
+
+    <name>OPS4J Pax CDI Sample - OSGi Provider Producer Method</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.ops4j.pax.cdi</groupId>
+            <artifactId>pax-cdi-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-jcdi_1.0_spec</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>org.ops4j.pax.cdi.sample.osgi-provider-producer-method</Bundle-SymbolicName>
+                        <Require-Capability>
+                            org.ops4j.pax.cdi.extension; filter:="(&amp;(extension=pax-cdi-extension)(version&gt;=${version;==;${pax.cdi.osgi.version.clean}})(!(version&gt;=${version;=+;${pax.cdi.osgi.version.clean}})))",
+                            osgi.extender; filter:="(osgi.extender=pax.cdi)"
+                        </Require-Capability>
+                    </instructions>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>versions</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>cleanVersions</goal>
+                        </goals>
+                        <configuration>
+                            <versions>
+                                <pax.cdi.osgi.version.clean>${project.version}</pax.cdi.osgi.version.clean>
+                            </versions>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/pax-cdi-samples/pax-cdi-sample-osgi-provider-producer-method/src/main/java/sample/osgiProviderProducerMethod/Beans.java
+++ b/pax-cdi-samples/pax-cdi-sample-osgi-provider-producer-method/src/main/java/sample/osgiProviderProducerMethod/Beans.java
@@ -1,0 +1,22 @@
+package sample.osgiProviderProducerMethod;
+
+
+import org.ops4j.pax.cdi.api.OsgiServiceProvider;
+import org.ops4j.pax.cdi.api.SingletonScoped;
+
+import javax.enterprise.inject.Produces;
+
+
+/**
+ * @author mwinkels
+ * @since Jul 25, 2016
+ */
+public class Beans {
+
+    @Produces
+    @OsgiServiceProvider
+    @SingletonScoped
+    public Greeter greeter() {
+        return new EnglishGreeter();
+    }
+}

--- a/pax-cdi-samples/pax-cdi-sample-osgi-provider-producer-method/src/main/java/sample/osgiProviderProducerMethod/EnglishGreeter.java
+++ b/pax-cdi-samples/pax-cdi-sample-osgi-provider-producer-method/src/main/java/sample/osgiProviderProducerMethod/EnglishGreeter.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2013 Harald Wellmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample.osgiProviderProducerMethod;
+
+/**
+ * @author mwinkels
+ * @since Jul 25, 2016
+ */
+public class EnglishGreeter implements Greeter {
+
+    @Override
+    public String sayHello() {
+        return "Hello!";
+    }
+}

--- a/pax-cdi-samples/pax-cdi-sample-osgi-provider-producer-method/src/main/java/sample/osgiProviderProducerMethod/Greeter.java
+++ b/pax-cdi-samples/pax-cdi-sample-osgi-provider-producer-method/src/main/java/sample/osgiProviderProducerMethod/Greeter.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2013 Harald Wellmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sample.osgiProviderProducerMethod;
+
+
+/**
+ * @author mwinkels
+ * @since Jul 25, 2016
+ */
+public interface Greeter {
+    String sayHello();
+}

--- a/pax-cdi-samples/pom.xml
+++ b/pax-cdi-samples/pom.xml
@@ -24,6 +24,7 @@
         <module>pax-cdi-sample5-client1</module>
         <module>pax-cdi-sample5-client2</module>
         <module>pax-cdi-sample6</module>
+        <module>pax-cdi-sample-osgi-provider-producer-method</module>
     </modules>
 
 </project>


### PR DESCRIPTION
When the @OsgiServiceProvider annotation is used on a producer method (which should be possible according to its JavaDoc) the following exception is thrown:

```
15:19:10.895 [Start Level Event Dispatcher] INFO  o.o.p.c.e.i.c.ComponentLifecycleManager - component Greeter, Name:null, WebBeans Type:PRODUCERMETHOD, API Types:[java.lang.Object,sample.osgiProviderProducerMethod.Greeter], Qualifiers:[javax.enterprise.inject.Any,org.ops4j.pax.cdi.api.OsgiServiceProvider] is available
15:19:10.912 [Start Level Event Dispatcher] ERROR o.o.pax.cdi.spi.AbstractCdiContainer - 
java.lang.NullPointerException: null
	at org.ops4j.pax.cdi.extension.impl.component.ComponentLifecycleManager.registerService(ComponentLifecycleManager.java:183) ~[pax-cdi-extension-0.13.0-SNAPSHOT.jar:na]
	at org.ops4j.pax.cdi.extension.impl.component.ComponentLifecycleManager.start(ComponentLifecycleManager.java:107) ~[pax-cdi-extension-0.13.0-SNAPSHOT.jar:na]
	at org.ops4j.pax.cdi.extension.impl.component.ComponentLifecycleManager$$OwbNormalScopeProxy0.start(org/ops4j/pax/cdi/extension/impl/component/ComponentLifecycleManager.java) ~[na:na]
	at org.ops4j.pax.cdi.extension.impl.BeanBundleImpl.onInitialized(BeanBundleImpl.java:60) ~[pax-cdi-extension-0.13.0-SNAPSHOT.jar:na]
	...

```

The integration test in this pull requests show the problem. The last commit proposes a fix. 